### PR TITLE
v2.1.6: prevent DEPRECATION WARNING of has_many on Rails 4.0

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -81,7 +81,9 @@ module CollectiveIdea #:nodoc:
           has_many_children_options.update(ar_callback => options[ar_callback]) if options[ar_callback]
         end
 
-        has_many :children, has_many_children_options
+        ActiveSupport::Deprecation.silence do
+          has_many :children, has_many_children_options
+        end
 
         attr_accessor :skip_before_destroy
 


### PR DESCRIPTION
On Rails 4.0.2:
<pre>
DEPRECATION WARNING: The following options in your Issue.has_many :children declaration are deprecated: :order. Please use a scope block instead. For example, the following:

    has_many :spam_comments, conditions: { spam: true }, class_name: 'Comment'

should be rewritten as the following:

    has_many :spam_comments, -> { where spam: true }, class_name: 'Comment'
. (called from acts_as_nested_set at lib/plugins/awesome_nested_set/lib/awesome_nested_set/awesome_nested_set.rb:84)
</pre>